### PR TITLE
Add poseidon to Open KnowHow

### DIFF
--- a/okh-poseidon.yml
+++ b/okh-poseidon.yml
@@ -1,7 +1,3 @@
-# Open know-how manifest
-# according to The Open Know-How Manifest Specification Version 1.0
-# for more info, see http://openknowhow.org/
-
 # The content of this manifest file is licensed under a Creative Commons Attribution 4.0 International License.
 # Licenses for modification and distribution of the hardware, documentation, source-code, etc are stated separately.
 
@@ -9,18 +5,18 @@
 
 # Manifest metadata
 
-date-created: 2020-02-28                   # YYYY-MM-DD
+date-created: 2020-02-28                     # YYYY-MM-DD
 
 #date-updated: [value]                      # YYYY-MM-DD
 
 manifest-author:
-  name: Andre Maia Chagas                  # required | text
+  name:  Andre Maia Chagas                 # required | text
   affiliation: University of Sussex        # text
   email: a.maia-chagas@sussex.ac.uk        # email address
 
-manifest-language: EN-UK
+manifest-language: English-UK
 
-#documentation-language: [language-code]-[region]
+documentation-language: English-UK
 
 #manifest-is-translation:
 #  title: [value]                           # text | Title of the original
@@ -36,17 +32,17 @@ manifest-language: EN-UK
 
 # Properties
 
-title: Poseidon: Open source bioinstrumentation                             # required | text | A title to identify the thing
+title: Poseidon - Open source bioinstrumentation                   # required | text | A title to identify the thing
 
 description: |                             # required | paragraph
   An easy-to-use, highly customizable, and open source syringe pump and microscope system.
-#intended-use: |                            # recommended | Paragraph
+
+intended-use: |                            # recommended | Paragraph
   The poseidon syringe pump and microscope system is an open source alternative to commercial systems. It costs less than $400 and can be assembled in an hour. It uses 3D printed parts and common components that can be easily purchased either from Amazon or other retailers. The microscope and pumps can be used together in microfluidics experiments, or independently for other applications. The pumps and microscope can be run from a Windows, Mac, Linux, or Raspberry Pi computer with an easy to use GUI.
 
 keywords:                                  # At least one keyword is recommended | text array
   - Syringe pump
   - Microscopy
-  - imaging
 
 project-link: https://github.com/pachterlab/poseidon               # At least project-link or documentation-home is required, otherwise recommended | absolute path URL
 
@@ -61,8 +57,8 @@ project-link: https://github.com/pachterlab/poseidon               # At least pr
 #    - platform: [value]                    # text
 #      user-handle: [value]                 # text
 
-contributors:                              # recommended
-  - name: [contributor 1]                  # text
+#contributors:                              # recommended
+#  - name: [contributor 1]                  # text
 #    affiliation: [value]                   # text
 #    email: [value]                         # email address
 
@@ -114,7 +110,7 @@ license:                                   # At least one license is required | 
 
 # Documentation
 
-documentation-home: https://pachterlab.github.io/poseidon/      # At least one of the project-link or documentation-home fields is required | absolute path
+documentation-home: https://pachterlab.github.io/poseidon      # At least one of the project-link or documentation-home fields is required | absolute path
 
 #archive-download: [value]                 # Absolute or relative path
 

--- a/okh-poseidon.yml
+++ b/okh-poseidon.yml
@@ -1,0 +1,170 @@
+# Open know-how manifest
+# according to The Open Know-How Manifest Specification Version 1.0
+# for more info, see http://openknowhow.org/
+
+# The content of this manifest file is licensed under a Creative Commons Attribution 4.0 International License.
+# Licenses for modification and distribution of the hardware, documentation, source-code, etc are stated separately.
+
+# Remove any fields that are not used. Comments (beginning with '#') may also be removed.
+
+# Manifest metadata
+
+date-created: 2020-02-28                   # YYYY-MM-DD
+
+#date-updated: [value]                      # YYYY-MM-DD
+
+manifest-author:
+  name: Andre Maia Chagas                  # required | text
+  affiliation: University of Sussex        # text
+  email: a.maia-chagas@sussex.ac.uk        # email address
+
+manifest-language: EN-UK
+
+#documentation-language: [language-code]-[region]
+
+#manifest-is-translation:
+#  title: [value]                           # text | Title of the original
+#  manifest: [value]                        # URL - Absolute path | OKH manifest location
+#  web: [value]                             # URL - Absolute path | web presence location
+#  lang: [language]-[region]                # language of original
+
+#documentation-is-translation:
+#  title: [value]                           # text | Title of the original
+#  manifest: [value]                        # URL - Absolute path | OKH manifest location
+#  web: [value]                             # URL - Absolute path | web presence location
+#  lang: [language]-[region]                # language of original
+
+# Properties
+
+title: Poseidon: Open source bioinstrumentation                             # required | text | A title to identify the thing
+
+description: |                             # required | paragraph
+  An easy-to-use, highly customizable, and open source syringe pump and microscope system.
+#intended-use: |                            # recommended | Paragraph
+  The poseidon syringe pump and microscope system is an open source alternative to commercial systems. It costs less than $400 and can be assembled in an hour. It uses 3D printed parts and common components that can be easily purchased either from Amazon or other retailers. The microscope and pumps can be used together in microfluidics experiments, or independently for other applications. The pumps and microscope can be run from a Windows, Mac, Linux, or Raspberry Pi computer with an easy to use GUI.
+
+keywords:                                  # At least one keyword is recommended | text array
+  - Syringe pump
+  - Microscopy
+  - imaging
+
+project-link: https://github.com/pachterlab/poseidon               # At least project-link or documentation-home is required, otherwise recommended | absolute path URL
+
+#health-safety-notice: |                    # paragraph
+#  [value]
+
+#contact:
+#  name: [value]                            # text
+#  affiliation: [value]                     # text
+#  email: [value]                           # email address
+#  social:
+#    - platform: [value]                    # text
+#      user-handle: [value]                 # text
+
+contributors:                              # recommended
+  - name: [contributor 1]                  # text
+#    affiliation: [value]                   # text
+#    email: [value]                         # email address
+
+image: https://user-images.githubusercontent.com/10369156/51078589-5a5f8800-166c-11e9-8312-50b374d574d9.jpg                             # recommended | absolute or relative path
+
+#version: [value]                           # text
+
+#development-stage: [value]                 # text
+
+made: true                        # boolean - true or false
+
+#made-independently: [true/false]           # boolean - true or false
+
+#standards-used:
+#  - standard-title: [value]                # Required where used | Title of the standard used in developing the design or documentation
+#    publisher: [value]                     # Publisher of the standard
+#    reference: [value]                     # Reference indentifier of the standard (e.g. ISO 9001)
+#    certification:                         # If certification has been granted confirming compliance with the standard
+#      - certifier: [value]                 # Individual or organisation granting the certification. Use "Self" for self-certification
+#        date-awarded: [value]              # Date certification was granted
+#        link: [value]                      # Link to evidence of certification (e.g. certificate). Use an an absolute path to an external resource or an absolute or relative path to evidence within the documentation.
+
+#derivative-of:
+#  title: [value]                           # text | Title of the original
+#  manifest: [value]                        # URL - Absolute path | OKH manifest location
+#  web: [value]                             # URL - Absolute path | web presence location
+
+#variant-of:
+#  title: [value]                           # text | Title of the original
+#  manifest: [value]                        # URL - Absolute path | OKH manifest location
+#  web: [value]                             # URL - Absolute path | web presence location
+
+#sub:
+#  title: [sub 1]                           # text | Title of the original
+#  manifest: [value]                        # URL - Absolute path | OKH manifest location
+#  web: [value]                             # URL - Absolute path | web presence location
+
+# License
+
+license:                                   # At least one license is required | The format should be an SPDX identifier. See https://spdx.org/licenses/hardware: [value] # recommended | The license under which the hardware is released
+  #hardware: [value]                        # recommended | The license under which the documentation is released
+  documentation: BSD-2-Clause              # recommended | The license under which the documentation is released
+  #software: [value]                        # recommended where software is used | The license under which the software is released
+
+#licensor:
+#  name: [value]                            # text
+#  affiliation: [value]                     # text
+#  email: [value]                           # email address
+
+# Documentation
+
+documentation-home: https://pachterlab.github.io/poseidon/      # At least one of the project-link or documentation-home fields is required | absolute path
+
+#archive-download: [value]                 # Absolute or relative path
+
+#design-files:                             # recommended
+#  - path: [value]                         # Absolute or relative path
+#    title: [value]                        # text
+
+#schematics:                               # recommended where applicable
+#  - path: [value]                         # Absolute or relative path
+#    title: [value]                        # text
+
+#bom: [value]                              # recommended | absolute or relative path | Direct the maker to the Bill of Materials
+
+#tool-list: [value]                        # recommended | absolute or relative path | Direct the maker to a list of tools required to make the thing
+
+#making-instructions:                      # recommended
+#  - path: [value]                         # Absolute or relative path
+#    title: [value]                        # text
+
+#manufacturing-files:                      # recommended where applicable
+#  - path: [value]                         # Absolute or relative path
+#    title: [value]                        # text
+
+#risk-assessment:                          # recommended
+#  - path: [value]                         # Absolute or relative path
+#    title: [value]                        # text
+
+#tool-settings:                            # recommended where applicable
+#  - path: [value]                         # Absolute or relative path
+#    title: [value]                        # text
+
+#quality-instructions:
+#  - path: [value]                         # Absolute or relative path
+#    title: [value]                        # text
+
+#operating-instructions:                   # recommended
+#  - path: [value]                         # Absolute or relative path
+#    title: [value]                        # text
+
+#maintenance-instructions: [value]         # recommended
+#  - path: [value]                         # Absolute or relative path
+#    title: [value]                        # text
+
+#disposal-instructions: [value]            # recommended
+#  - path: [value]                         # Absolute or relative path
+#    title: [value]                        # text
+
+#software:                                 # recommended where applicable | Source code or executable software that the thing uses
+#  - path: [value]                         # Absolute or relative path
+#    title: [value]                        # text
+
+# User defined Fields
+# Include any custom / extended fields here

--- a/okh-poseidon.yml
+++ b/okh-poseidon.yml
@@ -49,8 +49,8 @@ project-link: https://github.com/pachterlab/poseidon               # At least pr
 #health-safety-notice: |                    # paragraph
 #  [value]
 
-#contact:
-#  name: [value]                            # text
+contact:
+  name: A. Sina Booeshaghi                  # text
 #  affiliation: [value]                     # text
 #  email: [value]                           # email address
 #  social:

--- a/okh-poseidon.yml
+++ b/okh-poseidon.yml
@@ -122,7 +122,7 @@ documentation-home: https://pachterlab.github.io/poseidon      # At least one of
 #  - path: [value]                         # Absolute or relative path
 #    title: [value]                        # text
 
-#bom: [value]                              # recommended | absolute or relative path | Direct the maker to the Bill of Materials
+bom: https://github.com/OKH-Forks/poseidon/blob/release/HARDWARE/poseidon_bill-of-materials_v1.0_2019-01-28.xlsx                              # recommended | absolute or relative path | Direct the maker to the Bill of Materials
 
 #tool-list: [value]                        # recommended | absolute or relative path | Direct the maker to a list of tools required to make the thing
 

--- a/okh-poseidon.yml
+++ b/okh-poseidon.yml
@@ -50,9 +50,9 @@ project-link: https://github.com/pachterlab/poseidon               # At least pr
 #  [value]
 
 contact:
-  name: A. Sina Booeshaghi                  # text
+  name: Lior Patcher                  # text
 #  affiliation: [value]                     # text
-#  email: [value]                           # email address
+  email:  lpachter@caltech.edu                           # email address
 #  social:
 #    - platform: [value]                    # text
 #      user-handle: [value]                 # text
@@ -103,10 +103,10 @@ license:                                   # At least one license is required | 
   documentation: BSD-2-Clause              # recommended | The license under which the documentation is released
   #software: [value]                        # recommended where software is used | The license under which the software is released
 
-#licensor:
-#  name: [value]                            # text
+licensor:
+  name: Lior Patcher                  # text
 #  affiliation: [value]                     # text
-#  email: [value]                           # email address
+  email:  lpachter@caltech.edu
 
 # Documentation
 


### PR DESCRIPTION
Hi!

My name is [Andre](amchagas.github.io), I work at the University of Sussex as a Research Bioengineer developing Open source tools for research and education. I'm currently working with a group of people to make hardware easy to discover.

Named [Open Know How](https://openknowhow.org/) we've come up with a system where a simple file with metadata about a certain project would live in the project documentation page.

From there we are working to create a web-crawler that is going to find these files and index them (the ultimate goal would be to have something like a "hardware" tab on google search (as other search engines).

I took the liberty of creating one of these files for your project, with the bare minimum for it to be indexed in the future! I hope you don't mind! (it is just this .yml file that should live in the root of the repository).

I created this, because I think this is a useful project and it would be great to have it listed on the Open Know-how repository, so that it would be even easier for other people to find it!

You can find our proof-of-concept website, containing other projects that already have a manifest [here](https://okh.now.sh/)

You can find more technical information about Open Know How [here](https://app.standardsrepo.com/MakerNetAlliance/OpenKnowHow/wiki)
